### PR TITLE
chore(deprecate): notice of function core app support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,18 @@
 # Branch Commit Buildkite Plugin
 
+> [!WARNING]
+> **This plugin is deprecated.** Commit verification is now supported natively by the Buildkite Agent via the `checkout.commit_verification` attribute on [command steps](https://buildkite.com/docs/pipelines/configure/step-types/command-step), which supports the same `strict` and `warn` modes:
+>
+> ```yaml
+> steps:
+>   - label: ":pipeline:"
+>     command: buildkite-agent pipeline upload
+>     checkout:
+>       commit_verification: strict
+> ```
+>
+> Please migrate to the native functionality instead of using this plugin.
+
 A Buildkite plugin that verifies the build commit exists on the specified branch. Designed for UI-triggered builds where a user may select a commit that doesn't belong to the target branch.
 
 The plugin only runs when `BUILDKITE_SOURCE` is `ui`. For all other build sources it exits immediately.


### PR DESCRIPTION
## Description

**Don't merge until core app docs update**

This reflects changes in the core app which means this plugin is no longer required, nor should it be considered _maintained_.
